### PR TITLE
Separate approver policy from mechanics

### DIFF
--- a/pkg/approvers/always/always.go
+++ b/pkg/approvers/always/always.go
@@ -1,9 +1,6 @@
 package always
 
 import (
-	"strings"
-
-	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/kapprover/pkg/approvers"
 	"k8s.io/client-go/kubernetes/typed/certificates/v1alpha1"
 	certificates "k8s.io/client-go/pkg/apis/certificates/v1alpha1"
@@ -24,62 +21,30 @@ func init() {
 // respectively kubeletBootstrapUsername / kubeletBootstrapGroup.
 type Always struct{}
 
-// Approve approves CSRs in a loop.
-func (*Always) Approve(client v1alpha1.CertificateSigningRequestInterface, request *certificates.CertificateSigningRequest) error {
+// Approve approves CSRs
+func (*Always) Approve(client v1alpha1.CertificateSigningRequestInterface, request *certificates.CertificateSigningRequest) (certificates.CertificateSigningRequestCondition, error) {
 	condition := certificates.CertificateSigningRequestCondition{
 		Type:    certificates.CertificateApproved,
 		Reason:  "AutoApproved",
 		Message: "Auto approving of all kubelet CSRs is enabled on bootkube",
 	}
 
-	for {
-		// Verify that the CSR hasn't been approved or denied already.
-		//
-		// There are only two possible conditions (CertificateApproved and
-		// CertificateDenied). Therefore if the CSR already has a condition,
-		// it means that the request has already been approved or denied, and that
-		// we should ignore the request.
-		if len(request.Status.Conditions) > 0 {
-			return nil
-		}
-
-		// Ensure the CSR has been submitted by a kubelet performing its TLS
-		// bootstrapping by checking the username and the group.
-		if request.Spec.Username != kubeletBootstrapUsername {
-			return nil
-		}
-
-		isKubeletBootstrapGroup := false
-		for _, group := range request.Spec.Groups {
-			if group == kubeletBootstrapGroup {
-				isKubeletBootstrapGroup = true
-				break
-			}
-		}
-		if !isKubeletBootstrapGroup {
-			return nil
-		}
-
-		// Approve the CSR.
-		request.Status.Conditions = append(request.Status.Conditions, condition)
-
-		// Submit the updated CSR.
-		if _, err := client.UpdateApproval(request); err != nil {
-			if strings.Contains(err.Error(), "the object has been modified") {
-				// The CSR might have been updated by a third-party, retry until we
-				// succeed.
-				request, err = client.Get(request.ObjectMeta.Name)
-				if err != nil {
-					return err
-				}
-				continue
-			}
-
-			return err
-		}
-
-		log.Infof("Successfully approved %q", request.ObjectMeta.Name)
-
-		return nil
+	// Ensure the CSR has been submitted by a kubelet performing its TLS
+	// bootstrapping by checking the username and the group.
+	if request.Spec.Username != kubeletBootstrapUsername {
+		return approvers.NoAction, nil
 	}
+
+	isKubeletBootstrapGroup := false
+	for _, group := range request.Spec.Groups {
+		if group == kubeletBootstrapGroup {
+			isKubeletBootstrapGroup = true
+			break
+		}
+	}
+	if !isKubeletBootstrapGroup {
+		return approvers.NoAction, nil
+	}
+
+	return condition, nil
 }

--- a/pkg/approvers/approvers.go
+++ b/pkg/approvers/approvers.go
@@ -13,9 +13,13 @@ var (
 	approversM sync.RWMutex
 )
 
-// Approver reprensents anything capable to validating and approving a CSR.
+var (
+	NoAction = certificates.CertificateSigningRequestCondition{}
+)
+
+// Approver represents anything capable of validating and approving a CSR.
 type Approver interface {
-	Approve(v1alpha1.CertificateSigningRequestInterface, *certificates.CertificateSigningRequest) error
+	Approve(v1alpha1.CertificateSigningRequestInterface, *certificates.CertificateSigningRequest) (certificates.CertificateSigningRequestCondition, error)
 }
 
 // Register makes an Approver available by the provided name.
@@ -44,7 +48,7 @@ func Register(name string, a Approver) {
 	approvers[name] = a
 }
 
-// List returns the list of the registered approvers's name.
+// List returns the list of the registered approvers' names.
 func List() []string {
 	approversM.RLock()
 	defer approversM.RUnlock()
@@ -57,7 +61,7 @@ func List() []string {
 	return ret
 }
 
-// Unregister removes a Approverwith a particular name from the list.
+// Unregister removes an Approver with a particular name from the list.
 func Unregister(name string) {
 	approversM.Lock()
 	defer approversM.Unlock()


### PR DESCRIPTION
Hoist up code common to all approvers, leaving approvers to deal
solely with approval policy.